### PR TITLE
PHP 8 support

### DIFF
--- a/src/PosixSemaphore.php
+++ b/src/PosixSemaphore.php
@@ -86,10 +86,11 @@ class PosixSemaphore implements Semaphore
     }
 
     /**
-     * Private to prevent serialization.
+     * Prevent serialization.
      */
-    private function __sleep()
+    public function __sleep()
     {
+        throw new SyncException('A semaphore cannot be serialized!');
     }
 
     public function getId(): string

--- a/src/PosixSemaphore.php
+++ b/src/PosixSemaphore.php
@@ -90,7 +90,7 @@ class PosixSemaphore implements Semaphore
      */
     public function __sleep()
     {
-        throw new SyncException('A semaphore cannot be serialized!');
+        throw new \Error('A semaphore cannot be serialized!');
     }
 
     public function getId(): string


### PR DESCRIPTION
On PHP 8, private __sleep methods issue a warning/exception.