### PR TITLE
Update for Revolt 0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8",
         "amphp/amp": "^3",
-        "revolt/event-loop": "^0.1"
+        "revolt/event-loop": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
Not sure if this should be `^0.1 || ^0.2` or just `^0.2`.  Current state causes a conflict at the moment where `amphp/http-client:^5` can't be installed because:
```
  Problem 1
    - Root composer.json requires amphp/sync ^2 -> satisfiable by amphp/sync[v2.0.0-beta.1, v2.x-dev].
    - amphp/pipeline dev-master requires revolt/event-loop ^0.2 -> satisfiable by revolt/event-loop[v0.2.0].
    - amphp/pipeline 1.x-dev is an alias of amphp/pipeline dev-master and thus requires it to be installed too.
    - You can only install one version of a package, so only one of these can be installed: revolt/event-loop[dev-main, v0.1.1, v0.2.0].
    - amphp/http-server v3.x-dev requires amphp/pipeline v1.x-dev -> satisfiable by amphp/pipeline[1.x-dev (alias of dev-master)].
    - amphp/sync[v2.0.0-beta.1, ..., v2.x-dev] require revolt/event-loop ^0.1 -> satisfiable by revolt/event-loop[v0.1.0, v0.1.1].
    - Root composer.json requires amphp/http-server ^3 -> satisfiable by amphp/http-server[v3.x-dev].
```