### PR TITLE
Add re-entry support to synchronized

### DIFF
--- a/test/SynchronizedTest.php
+++ b/test/SynchronizedTest.php
@@ -27,4 +27,77 @@ final class SynchronizedTest extends AsyncTestCase
 
         self::assertEquals([0, 1, 2], await($futures));
     }
+
+    public function testSynchronizedReentry(): void
+    {
+        $mutex = new LocalMutex;
+        $count = 0;
+
+        synchronized($mutex, function () use ($mutex, &$count) {
+            $count++;
+
+            synchronized($mutex, function () use (&$count) {
+                $count++;
+            });
+        });
+
+        self::assertSame(2, $count);
+    }
+
+    public function testSynchronizedReentryAsync(): void
+    {
+        $mutex = new LocalMutex;
+        $count = 0;
+
+        synchronized($mutex, function () use ($mutex, &$count) {
+            async(function () use ($mutex, &$count) {
+                synchronized($mutex, function () use (&$count) {
+                    $count++;
+                });
+            });
+
+            delay(1);
+
+            $count = 10;
+        });
+
+        delay(2);
+
+        // The async synchronized block must be executed after $count = 10 is executed
+        self::assertSame(11, $count);
+    }
+
+    public function testSynchronizedReentryDifferentLocks(): void
+    {
+        $mutexA = new LocalMutex;
+        $mutexB = new LocalMutex;
+
+        $lock = $mutexB->acquire();
+
+        $op = async(function () use ($mutexA, $mutexB) {
+            print 'Before ';
+
+            synchronized($mutexA, function () use ($mutexB) {
+                print 'before ';
+
+                synchronized($mutexB, function () {
+                    print 'X ';
+                });
+
+                print 'after ';
+            });
+
+            print 'After ';
+        });
+
+        delay(1);
+
+        print 'Unlock ';
+
+        $lock->release();
+
+        $op->await();
+
+        self::expectOutputString('Before before Unlock X after After ');
+    }
 }


### PR DESCRIPTION
If you have many methods that use `synchronized` on a single mutex, but they should be able to call each other, it becomes a mess without re-entry support.

This does have the side effect of a slight behavior change in case a `Semaphore` instead of a `Mutex` is passed. While a `Mutex` simply didn't work before, a `Semaphore` would have consumed two or more locks instead of just one now on nested calls.